### PR TITLE
fix: 검색단어 하이라이트 에러 수정

### DIFF
--- a/client/src/components/views/Search/Sections/CompletionBox.js
+++ b/client/src/components/views/Search/Sections/CompletionBox.js
@@ -4,13 +4,29 @@ import SearchIcon from '@mui/icons-material/Search';
 
 export default function CompletionBox({ content, searchWord, setSearchWord }) {
   console.log(content);
-  const [leftWord, setLeftWord] = useState('');
   const onComplete = () => {
     setSearchWord(content.groupName);
   };
-  useEffect(() => {
-    setLeftWord(content.groupName.substring(searchWord.length));
-  }, [searchWord]);
+  const highlightedText = (text, query) => {
+    if (query !== '' && text.includes(query)) {
+      const parts = text.split(new RegExp(`(${query})`, 'gi'));
+
+      return (
+        <>
+          {parts.map((part, index) =>
+            part.toLowerCase() === query.toLowerCase() ? (
+              <mark key={index}>{part}</mark>
+            ) : (
+              part
+            ),
+          )}
+        </>
+      );
+    }
+
+    return text;
+  };
+  useEffect(() => {}, []);
   return (
     <Box
       sx={{
@@ -24,8 +40,7 @@ export default function CompletionBox({ content, searchWord, setSearchWord }) {
       onClick={onComplete}
     >
       <SearchIcon />
-      <Typography sx={{ color: '#3EA5E2' }}>{searchWord}</Typography>
-      <Typography>{leftWord}</Typography>
+      <Typography>{highlightedText(content.groupName, searchWord)}</Typography>
     </Box>
   );
 }

--- a/client/src/components/views/Search/Sections/SearchBar.js
+++ b/client/src/components/views/Search/Sections/SearchBar.js
@@ -30,7 +30,6 @@ function SearchBar(props) {
       target: { value },
     } = e;
     setSearchWord(value);
-    
   };
 
   const onKeyPress = e => {


### PR DESCRIPTION
검색시 해당하는 단어가 있으면 그 부분만 하이라이트 된다.

- html의 mark 태그 활용
- 대소문자만 다를 경우 자동완성은 이뤄지나 하이라이트는 되지 않음